### PR TITLE
Wait for worker completion when cancellation is requested

### DIFF
--- a/WaybackDownloader/Logging/CollectedLogMessages.cs
+++ b/WaybackDownloader/Logging/CollectedLogMessages.cs
@@ -11,7 +11,8 @@ internal sealed class CollectedLogMessages
     public ImmutableArray<LogMessage> DrainMessages()
     {
         //Cannot use LINQ here - see https://github.com/dotnet/runtime/issues/101641
-        var array = ImmutableArray.CreateBuilder<LogMessage>(_messages.Count);
+        //Do not use .Count - this locks the ConcurrentQueue and is very slow
+        var array = ImmutableArray.CreateBuilder<LogMessage>(20);
         while (_messages.TryDequeue(out var m))
         {
             array.Add(m);

--- a/WaybackDownloader/MockDataHttpMessageHandler.cs
+++ b/WaybackDownloader/MockDataHttpMessageHandler.cs
@@ -36,9 +36,9 @@ internal sealed class MockDataHttpMessageHandler : HttpMessageHandler
         return a;
     }
 
-    //private static int _year = 1001;
-    //private static int GetYear() => Interlocked.Increment(ref _year);
-    private static int GetYear() => 2000;
+    private static int _year = 1001;
+    private static int GetYear() => Interlocked.Increment(ref _year);
+    //private static int GetYear() => 2000;
 
     private static async Task<HttpResponseMessage> CreateHtmlResponseAsync(CancellationToken cancellationToken)
     {

--- a/WaybackDownloader/Properties/launchSettings.json
+++ b/WaybackDownloader/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "WaybackDownloader": {
       "commandName": "Project",
-      "commandLineArgs": "archive.org \"./pages\" -m exact --limitPages 10000 -p SomeString1 -r 1 --historyLogDir=./logFileLocation --useMockHandler"
+      "commandLineArgs": "archive.org \"./pages\" -m exact --limitPages 10000 -p SomeString1 -r 10 --historyLogDir=./logFileLocation --useMockHandler --clearHistory"
     }
   }
 }

--- a/WaybackDownloader/Services/PageWorkerRunner.cs
+++ b/WaybackDownloader/Services/PageWorkerRunner.cs
@@ -36,7 +36,7 @@ public sealed class PageWorkerRunner(IServiceProvider serviceProvider, ILogger<P
     private int _numberOfEvaluationsAtRequiredSpeed;
     private async Task EvaluateLimitAsync(string outputDir, int requestedDownloadLimit, CancellationToken cancellationToken)
     {
-        const int SegmentDurationSeconds = 5;
+        const int SegmentDurationSeconds = 2;
         const float MinimumThreshold = 0.9f;
         await Task.Yield();
         while (!cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
This ensures that any trailing log messages are correctly output by the UI, as the UI is now stopped only after the workers completely shut down.